### PR TITLE
Update docs

### DIFF
--- a/BuildTargetImage.md
+++ b/BuildTargetImage.md
@@ -42,7 +42,7 @@ Configure your build variables (`$BUILD_VARS`) on the command line or in the
       starting any build
 
 Sample values for `$DESIRED_PLATFORM` are `barefoot, broadcom, marvell,
-mellanox, cavium, centec, nephos, innovium, p4, vs`.
+mellanox, cavium, centec, nephos, innovium, vs`.
 
 Run the make commands.
 

--- a/BuildTargetImage.md
+++ b/BuildTargetImage.md
@@ -17,9 +17,9 @@ python,` and `j2cli`. If you need to do a local build of the ONOS driver and SAI
 pipeline, you will also need `maven` and a Java JDK.
 
 1. Clone the PINS/sonic-buildimage repository using one of the following:
-    * HTTPS:       `git clone https://github.com/Azure/sonic-buildimage.git`
-    * SSH:         `git clone git@github.com:Azure/sonic-buildimage.git`
-    * Github CLI:  `gh repo clone Azure/sonic-buildimage`
+    * HTTPS:       `git clone https://github.com/sonic-net/sonic-buildimage.git`
+    * SSH:         `git clone git@github.com:sonic-net/sonic-buildimage.git`
+    * Github CLI:  `gh repo clone sonic-net/sonic-buildimage`
 2. Change to the new directory: `cd sonic-buildimage`
 3. Download submodules and checkout the correct commit number: `make init`
 

--- a/Exercise1/README.md
+++ b/Exercise1/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 
 This exercise will take you through the deployment of the SONiC/PINS target
 image on your switches. If you have questions about SONiC deployment, see the
-[SONiC documentation](https://github.com/Azure/SONiC/wiki/).
+[SONiC documentation](https://github.com/sonic-net/SONiC/wiki/).
 
 ### Get the SONiC/PINS Target Image(s) for Your Switches
 
@@ -46,14 +46,14 @@ Three installers are available to deploy the SONiC/PINS target image.
 1. The SONiC installer upgrades a switch with SONiC installed to SONiC/PINS.
    (brownfield) \
 Reference: [SONiC
-installer](https://github.com/Azure/SONiC/blob/master/doc/SONiC-User-Manual.md#3231-sonic-installer)
+installer](https://github.com/sonic-net/SONiC/blob/master/doc/SONiC-User-Manual.md#3231-sonic-installer)
 2. The ONIE installer bootstraps a switch without SONiC. If your switch does not
    have ONIE, you will need to install it first. (greenfield)  \
 Reference: [SONiC ONIE installation
-instructions](https://github.com/Azure/SONiC/blob/master/doc/SONiC-User-Manual.md#1121-install-sonic-onie-image)
+instructions](https://github.com/sonic-net/SONiC/blob/master/doc/SONiC-User-Manual.md#1121-install-sonic-onie-image)
 3. The Aboot installer bootstraps Arista switches without SONiC. (greenfield)  \
 Reference: [SONiC EOS installation
-instructions](https://github.com/Azure/SONiC/blob/master/doc/SONiC-User-Manual.md#1122-install-sonic-eos-image)
+instructions](https://github.com/sonic-net/SONiC/blob/master/doc/SONiC-User-Manual.md#1122-install-sonic-eos-image)
 
 #### SONiC Installer
 
@@ -320,7 +320,7 @@ use the `sudo config reload -y` command to restart the docker containers and
 incorporate the changes.
 
 The [Troubleshooting
-section](https://github.com/Azure/SONiC/blob/master/doc/SONiC-User-Manual.md#6-troubleshooting)
+section](https://github.com/sonic-net/SONiC/blob/master/doc/SONiC-User-Manual.md#6-troubleshooting)
 of the SONiC User Manual is helpful if you run into problems.
 
 ### Note About Custom Configuration

--- a/Exercise2/README.md
+++ b/Exercise2/README.md
@@ -28,7 +28,7 @@ each pair of connected interfaces matches.
 
 1. Login (`ssh`) to each switch and check the interface speed and that the
    expected interfaces are up. Reference: [SONiC Interfaces command
-   reference](https://github.com/Azure/sonic-utilities/blob/master/doc/Command-Reference.md#interfaces)
+   reference](https://github.com/sonic-net/sonic-utilities/blob/master/doc/Command-Reference.md#interfaces)
 
     ```
     Switch$ show interfaces status

--- a/Exercise5/README.md
+++ b/Exercise5/README.md
@@ -21,7 +21,7 @@ SD-Fabric. (Normally, the segment routing application relies on MPLS rules in
 the spines, but we use IPv4 routes in this case.) The result is that the fabric
 acts as one big router. For more information on the switch pipeline, you can
 find the P4 SAI tables here:
-[Azure/sonic-pins/sai_p4](https://github.com/Azure/sonic-pins/tree/main/sai_p4/instantiations/google).
+[sonic-net/sonic-pins/sai_p4](https://github.com/sonic-net/sonic-pins/tree/main/sai_p4/instantiations/google).
 The `middleblock.p4` instantiation of the SAI pipeline is close to what we used
 for our demonstration.
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,17 @@ to SONiC as described in the [PINS high-level design
 document](https://github.com/pins/SONiC/blob/pins-hld/doc/pins/pins_hld.md).
 [P4Runtime
 (P4RT)](https://github.com/pins/SONiC/blob/p4rt_hld/doc/pins/p4rt_app_hld.md)
-(code: [Azure/sonic-pins](https://github.com/Azure/sonic-pins)) is a new
+(code: [sonic-net/sonic-pins](https://github.com/sonic-net/sonic-pins)) is a new
 application running in its own container that receives P4 programming requests
 from an SDN controller and writes intents to new P4 tables. In
-[Azure/sonic-swss](https://github.com/Azure/sonic-swss),
+[sonic-net/sonic-swss](https://github.com/sonic-net/sonic-swss),
 [P4Orch](https://github.com/pins/SONiC/blob/pins-hld/doc/pins/pins_hld.md#p4-orchagent)
 and [P4RT
 tables](https://github.com/pins/SONiC/blob/pins-hld/doc/pins/pins_hld.md#p4-appl-db-tables)
 were added to process database entries, create SAI objects, and add them to the
 ASIC database. PINS also introduces modifications to
-[Azure/sonic-swss-common](https://github.com/Azure/sonic-swss-common) and
-[Azure/sonic-buildimage](https://github.com/Azure/sonic-buildimage).
+[sonic-net/sonic-swss-common](https://github.com/sonic-net/sonic-swss-common) and
+[sonic-net/sonic-buildimage](https://github.com/sonic-net/sonic-buildimage).
 
 ### Tutorial Outline
 
@@ -81,9 +81,9 @@ The tutorial and hands-on exercises familiarize users with PINS
 ([webpage](https://opennetworking.org/pins/), [Working Group Github
 repositories](https://github.com/pins),
 [wiki](https://wiki.opennetworking.org/display/COM/PINS)). Activities assume a
-basic knowledge of SONiC ([webpage](https://azure.github.io/SONiC/), [Github
-repository](https://github.com/Azure/SONiC/),
-[wiki](https://github.com/Azure/SONiC/wiki)) and SDN, including the [P4
+basic knowledge of SONiC ([webpage](https://sonic-net.github.io/SONiC/), [Github
+repository](https://github.com/sonic-net/SONiC/),
+[wiki](https://github.com/sonic-net/SONiC/wiki)) and SDN, including the [P4
 language](https://p4.org) and ONOS ([webpage](https://opennetworking.org/onos/),
 [wiki](https://wiki.onosproject.org/display/ONOS/ONOS)). We provide participants
 with configuration files and scripts.

--- a/References.md
+++ b/References.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
 5. Pipelines: [Pipelines - DevOps Build](https://dev.azure.com/mssonic/build/_build),
    and [SONiC Image Pipelines](https://sonic-build.azurewebsites.net/ui/sonic/pipelines)
 6. Get a P4 compiler from Github, [p4c reference compiler](https://github.com/p4lang/p4c).
-7. To generate a new p4info: [https://github.com/Azure/sonic-pins/blob/main/sai_p4/instantiations/google/update_p4program_derived_files.sh](https://github.com/Azure/sonic-pins/blob/main/sai_p4/instantiations/google/update_p4program_derived_files.sh)
+7. To generate a new p4info: [https://github.com/sonic-net/sonic-pins/blob/main/sai_p4/instantiations/google/update_p4program_derived_files.sh](https://github.com/sonic-net/sonic-pins/blob/main/sai_p4/instantiations/google/update_p4program_derived_files.sh)
 
 ### Other Examples and Tutorials
 
@@ -23,6 +23,6 @@ SPDX-License-Identifier: Apache-2.0
 9. Trellis in a Box environment: [https://github.com/opennetworkinglab/routing/tree/master/trellis](https://github.com/opennetworkinglab/routing/tree/master/trellis)
 10. P4 tutorial: [https://github.com/p4lang/tutorials](https://github.com/p4lang/tutorials)
 11. ONOS tutorials: [https://wiki.onosproject.org/display/ONOS/Tutorials](https://wiki.onosproject.org/display/ONOS/Tutorials)
-12. SONiC Users: [https://github.com/Azure/SONiC/wiki/Quick-Start](https://github.com/Azure/SONiC/wiki/Quick-Start)
+12. SONiC Users: [https://github.com/sonic-net/SONiC/wiki/Quick-Start](https://github.com/sonic-net/SONiC/wiki/Quick-Start)
 13. Next-Gen SDN tutorial: [https://github.com/opennetworkinglab/ngsdn-tutorial](https://github.com/opennetworkinglab/ngsdn-tutorial)
 14. Stratum Getting Started tutorial: [https://github.com/stratum/tutorial](https://github.com/stratum/tutorial)


### PR DESCRIPTION
### Why I did it
- All repos have been transferred from [Azure](https://github.com/Azure) to [sonic-net](https://github.com/sonic-net).
- p4 is no longer a supported platform. Reference: https://github.com/sonic-net/sonic-buildimage/issues/2591#issuecomment-649425081